### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:
   # 手动触发部署
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+
 jobs:
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DXYD/dxyd.github.io/security/code-scanning/1](https://github.com/DXYD/dxyd.github.io/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimum permissions required for the workflow to function. Based on the workflow's operations, it needs to read repository contents and write to GitHub Pages. Therefore, we will set `contents: read` and `pages: write` permissions.

The `permissions` block will be added at the root level, applying to all jobs in the workflow. This ensures that the `GITHUB_TOKEN` used in the workflow has only the necessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
